### PR TITLE
Max stack size should directly be an int

### DIFF
--- a/src/item/component/MaxStackSizeComponent.php
+++ b/src/item/component/MaxStackSizeComponent.php
@@ -19,10 +19,8 @@ final class MaxStackSizeComponent implements ItemComponent {
 		return 'minecraft:max_stack_size';
 	}
 
-	public function getValue(): array {
-		return [
-			"value" => $this->maxStackSize
-		];
+	public function getValue(): int {
+		return $this->maxStackSize;
 	}
 
 	public function getPropertyMapping(): ?array {


### PR DESCRIPTION
Currently items has a max stack size of 1 by default...
```
string(1268) "TAG_Compound={
  "item_properties" => TAG_Compound={
    "allow_off_hand" => TAG_Byte=0
    "hidden_in_commands" => TAG_Byte=2
    "can_destroy_in_creative" => TAG_Byte=1
    "damage" => TAG_Int=0
    "enchantable_slot" => TAG_String="none"
    "enchantable_value" => TAG_Int=0
    "foil" => TAG_Byte=0
    "frame_count" => TAG_Int=1
    "hand_equipped" => TAG_Byte=0
    "liquid_clipped" => TAG_Byte=0
    "max_stack_size" => TAG_Int=64
    "mining_speed" => TAG_Float=1
    "should_despawn" => TAG_Byte=1
    "stacked_by_data" => TAG_Byte=0
    "use_animation" => TAG_Int=0
    "use_duration" => TAG_Int=0
    "creative_category" => TAG_Int=3
    "creative_group" => TAG_String="none"
    "minecraft:icon" => TAG_Compound={
      "textures" => TAG_Compound={
        "default" => TAG_String="gift_wrap"
      }
    }
  }
  "item_tags" => TAG_Compound={
  }
  "minecraft:hand_equipped" => TAG_Compound={
    "value" => TAG_Byte=0
  }
  "minecraft:display_name" => TAG_Compound={
    "value" => TAG_String="item.histeria:gift_wrap"
  }
  "minecraft:can_destroy_in_creative" => TAG_Compound={
    "value" => TAG_Byte=1
  }
  "minecraft:max_stack_size" => TAG_Compound={
    "value" => TAG_Int=64
  }
  "minecraft:damage" => TAG_Compound={
    "value" => TAG_Int=0
  }
}"
```
In the current version a classic component would look like that, however we want max_stack_size not to be a compound a int directly